### PR TITLE
Limit npm package to runtime files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,11 @@
     "@eslint/js": "^9.29.0",
     "eslint": "^9.29.0",
     "jest": "^30.0.0"
-  }
+  },
+  "files": [
+    "index.mjs",
+    "handlers",
+    "logger.js",
+    "collectInvocation.js"
+  ]
 }


### PR DESCRIPTION
## Summary
- restrict published files using `files` field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686c9449b45c83259cf16e571d221820