### PR TITLE
Fix Node CI install step

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-      - run: npm ci
+      - run: npm install
       - run: npm test
       - run: npm run lint


### PR DESCRIPTION
## Summary
- use `npm install` instead of `npm ci` in GitHub Actions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_686c95c89d508325af86fce965fe7df7