### PR TITLE
Decode CloudWatch Logs

### DIFF
--- a/handlers/handleCloudWatchLogs.js
+++ b/handlers/handleCloudWatchLogs.js
@@ -1,5 +1,6 @@
 import { logDebug } from '../logger.js';
 import collectInvocation from '../collectInvocation.js';
+import zlib from 'zlib';
 
 /**
  * Handle CloudWatch Logs subscription events.
@@ -16,6 +17,10 @@ export default async function handleCloudWatchLogs(event, context) {
   const invocation = collectInvocation(event, context, 'cloudWatchLogs');
   logDebug('invocation', invocation);
   logDebug('handleCloudWatchLogs', { requestId: context.awsRequestId });
-  console.log('Logs subscription payload received');
-  return {};
+  // Decode the base64 gzipped log payload
+  const compressed = Buffer.from(event.awslogs.data, 'base64');
+  const json = zlib.gunzipSync(compressed).toString('utf8');
+  const payload = JSON.parse(json);
+  payload.logEvents?.forEach(e => console.log('CloudWatch:', e.message));
+  return payload.logEvents || [];
 }

--- a/tests/handlers.test.js
+++ b/tests/handlers.test.js
@@ -1,4 +1,5 @@
 import { handler } from '../index.mjs';
+import zlib from 'zlib';
 
 describe('handler dispatch', () => {
   test('handles Alexa event', async () => {
@@ -119,10 +120,12 @@ describe('handler dispatch', () => {
   });
 
   test('handles CloudWatch Logs event', async () => {
-    const event = { awslogs: { data: 'dGVzdA==' } };
+    const payload = { messageType: 'DATA_MESSAGE', logEvents: [ { id: '1', timestamp: 0, message: 'hi' } ] };
+    const data = zlib.gzipSync(JSON.stringify(payload)).toString('base64');
+    const event = { awslogs: { data } };
     const context = { awsRequestId: '1' };
     const result = await handler(event, context);
-    expect(result).toEqual({});
+    expect(result).toEqual(payload.logEvents);
   });
 
   test('handles Custom Resource event', async () => {


### PR DESCRIPTION
## Summary
- decode CloudWatch log subscription payloads
- return parsed log events from handler
- verify decoding logic in unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686c998685f88325a1d300d3d4d9ba99