### PR TITLE
Add Node.js 22 to CI matrix

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- update workflow to test Node.js 22

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_686c9995737c8325852e325a4f29f887