### PR TITLE
Add config-driven dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,28 @@ The handler recognizes and dispatches events from:
 - Scheduled events
 - Fallback for other events
 
+## Custom Dispatch Configuration
+
+Handlers and event checks are listed in `dispatch-config.js`. Each entry
+contains a `check` function that inspects the incoming event and a `handler`
+module path. The dispatcher loads this file during initialization.
+
+To add your own event type:
+
+1. Create a new module under `handlers/` exporting a default async function.
+2. Add an object to `dispatch-config.js` with your detection logic and handler
+   path.
+
+Example:
+
+```js
+// dispatch-config.js
+export default [
+  // existing entries...
+  { check: e => e.myField === 'custom', handler: './handlers/handleMyEvent.js' },
+];
+```
+
 ### Example Event Payloads
 
 HTTP API v1 request:

--- a/dispatch-config.js
+++ b/dispatch-config.js
@@ -1,0 +1,34 @@
+function getRecordsSource(event) {
+  if (event.Records && Array.isArray(event.Records) && event.Records.length > 0) {
+    return event.Records[0].eventSource || event.Records[0].EventSource;
+  }
+  return undefined;
+}
+
+export default [
+  { check: e => e.request && e.session && e.context?.System, handler: './handlers/handleAlexa.js' },
+  { check: e => e.bot && e.userId && e.inputTranscript, handler: './handlers/handleLex.js' },
+  { check: e => e.arguments && e.identity && e.info, handler: './handlers/handleAppSync.js' },
+  { check: e => e.clientId && e.topic && e.payload, handler: './handlers/handleIoTRule.js' },
+  { check: e => e.records && Array.isArray(e.records) && e.records[0]?.recordId, handler: './handlers/handleFirehose.js' },
+  { check: e => e.invokingEvent && e.ruleParameters && e.resultToken, handler: './handlers/handleConfigRule.js' },
+  { check: e => e.taskToken || e.source === 'aws.states', handler: './handlers/handleStepFunctions.js' },
+  { check: e => e.version === '2.0' && e.requestContext?.routeKey && e.requestContext?.connectionId, handler: './handlers/handleWebSocket.js' },
+  { check: e => e.type === 'TOKEN' && e.methodArn, handler: './handlers/handleAuthorizerV1.js' },
+  { check: e => e.version === '2.0' && e.type === 'REQUEST', handler: './handlers/handleAuthorizerV2.js' },
+  { check: e => e.version === '2.0' && e.requestContext?.http?.method, handler: './handlers/handleHttpV2.js' },
+  { check: e => e.httpMethod, handler: './handlers/handleHttpV1.js' },
+  { check: e => e.requestContext?.elb, handler: './handlers/handleAlb.js' },
+  { check: e => e.Records && e.Records[0]?.cf, handler: './handlers/handleEdge.js' },
+  { check: e => e.awslogs?.data, handler: './handlers/handleCloudWatchLogs.js' },
+  { check: e => e.RequestType && e.ResponseURL, handler: './handlers/handleCustomResource.js' },
+  { check: e => e.triggerSource && e.userPoolId, handler: './handlers/handleCognito.js' },
+  { check: e => getRecordsSource(e) === 'aws:sqs', handler: './handlers/handleSqs.js' },
+  { check: e => getRecordsSource(e) === 'aws:sns', handler: './handlers/handleSns.js' },
+  { check: e => getRecordsSource(e) === 'aws:s3', handler: './handlers/handleS3.js' },
+  { check: e => getRecordsSource(e) === 'aws:dynamodb', handler: './handlers/handleDynamoDB.js' },
+  { check: e => getRecordsSource(e) === 'aws:kinesis', handler: './handlers/handleKinesis.js' },
+  { check: e => getRecordsSource(e) === 'aws:ses', handler: './handlers/handleSes.js' },
+  { check: e => e.source === 'aws.events', handler: './handlers/handleScheduled.js' },
+  { check: e => e.source && e['detail-type'], handler: './handlers/handleEventBridge.js' },
+];

--- a/dispatcher.js
+++ b/dispatcher.js
@@ -1,0 +1,60 @@
+import handleAlexa from './handlers/handleAlexa.js';
+import handleLex from './handlers/handleLex.js';
+import handleAppSync from './handlers/handleAppSync.js';
+import handleIoTRule from './handlers/handleIoTRule.js';
+import handleFirehose from './handlers/handleFirehose.js';
+import handleConfigRule from './handlers/handleConfigRule.js';
+import handleStepFunctions from './handlers/handleStepFunctions.js';
+import handleWebSocket from './handlers/handleWebSocket.js';
+import handleAuthorizerV1 from './handlers/handleAuthorizerV1.js';
+import handleAuthorizerV2 from './handlers/handleAuthorizerV2.js';
+import handleHttpV1 from './handlers/handleHttpV1.js';
+import handleHttpV2 from './handlers/handleHttpV2.js';
+import handleAlb from './handlers/handleAlb.js';
+import handleEdge from './handlers/handleEdge.js';
+import handleCloudWatchLogs from './handlers/handleCloudWatchLogs.js';
+import handleCustomResource from './handlers/handleCustomResource.js';
+import handleCognito from './handlers/handleCognito.js';
+import handleSqs from './handlers/handleSqs.js';
+import handleSns from './handlers/handleSns.js';
+import handleS3 from './handlers/handleS3.js';
+import handleDynamoDB from './handlers/handleDynamoDB.js';
+import handleKinesis from './handlers/handleKinesis.js';
+import handleSes from './handlers/handleSes.js';
+import handleEventBridge from './handlers/handleEventBridge.js';
+import handleScheduled from './handlers/handleScheduled.js';
+
+const handlerMap = {
+  './handlers/handleAlexa.js': handleAlexa,
+  './handlers/handleLex.js': handleLex,
+  './handlers/handleAppSync.js': handleAppSync,
+  './handlers/handleIoTRule.js': handleIoTRule,
+  './handlers/handleFirehose.js': handleFirehose,
+  './handlers/handleConfigRule.js': handleConfigRule,
+  './handlers/handleStepFunctions.js': handleStepFunctions,
+  './handlers/handleWebSocket.js': handleWebSocket,
+  './handlers/handleAuthorizerV1.js': handleAuthorizerV1,
+  './handlers/handleAuthorizerV2.js': handleAuthorizerV2,
+  './handlers/handleHttpV1.js': handleHttpV1,
+  './handlers/handleHttpV2.js': handleHttpV2,
+  './handlers/handleAlb.js': handleAlb,
+  './handlers/handleEdge.js': handleEdge,
+  './handlers/handleCloudWatchLogs.js': handleCloudWatchLogs,
+  './handlers/handleCustomResource.js': handleCustomResource,
+  './handlers/handleCognito.js': handleCognito,
+  './handlers/handleSqs.js': handleSqs,
+  './handlers/handleSns.js': handleSns,
+  './handlers/handleS3.js': handleS3,
+  './handlers/handleDynamoDB.js': handleDynamoDB,
+  './handlers/handleKinesis.js': handleKinesis,
+  './handlers/handleSes.js': handleSes,
+  './handlers/handleEventBridge.js': handleEventBridge,
+  './handlers/handleScheduled.js': handleScheduled,
+};
+
+export async function loadDispatchTable() {
+  const { default: config } = await import('./dispatch-config.js');
+  return config.map(({ check, handler }) => ({ check, handler: handlerMap[handler] }));
+}
+
+export const dispatchTablePromise = loadDispatchTable();

--- a/index.mjs
+++ b/index.mjs
@@ -6,78 +6,12 @@
  * under the `handlers/` directory.
  */
 import { logDebug } from './logger.js';
-import handleAlexa from './handlers/handleAlexa.js';
-import handleLex from './handlers/handleLex.js';
-import handleAppSync from './handlers/handleAppSync.js';
-import handleIoTRule from './handlers/handleIoTRule.js';
-import handleFirehose from './handlers/handleFirehose.js';
-import handleConfigRule from './handlers/handleConfigRule.js';
-import handleStepFunctions from './handlers/handleStepFunctions.js';
-import handleWebSocket from './handlers/handleWebSocket.js';
-import handleAuthorizerV1 from './handlers/handleAuthorizerV1.js';
-import handleAuthorizerV2 from './handlers/handleAuthorizerV2.js';
-import handleHttpV1 from './handlers/handleHttpV1.js';
-import handleHttpV2 from './handlers/handleHttpV2.js';
-import handleAlb from './handlers/handleAlb.js';
-import handleEdge from './handlers/handleEdge.js';
-import handleCloudWatchLogs from './handlers/handleCloudWatchLogs.js';
-import handleCustomResource from './handlers/handleCustomResource.js';
-import handleCognito from './handlers/handleCognito.js';
-import handleSqs from './handlers/handleSqs.js';
-import handleSns from './handlers/handleSns.js';
-import handleS3 from './handlers/handleS3.js';
-import handleDynamoDB from './handlers/handleDynamoDB.js';
-import handleKinesis from './handlers/handleKinesis.js';
-import handleSes from './handlers/handleSes.js';
-import handleEventBridge from './handlers/handleEventBridge.js';
-import handleScheduled from './handlers/handleScheduled.js';
+import { loadDispatchTable } from './dispatcher.js';
 import handleDefault from './handlers/handleDefault.js';
 
-/**
- * Extract the eventSource from the first record if the event contains
- * a `Records` array. Some AWS services use `EventSource` instead of
- * `eventSource`, so both are checked.
- *
- * @param {object} event - Incoming Lambda event.
- * @returns {string|undefined} the source service or undefined if not present.
- */
-function getRecordsSource(event) {
-  if (event.Records && Array.isArray(event.Records) && event.Records.length > 0) {
-    return event.Records[0].eventSource || event.Records[0].EventSource;
-  }
-  return undefined;
-}
-
-// Mapping of event detection functions to their corresponding handler.
-// Each `check` function returns true if the incoming event matches that
-// handler's expected structure.
-const dispatchTable = [
-  { check: e => e.request && e.session && e.context?.System, handler: handleAlexa },
-  { check: e => e.bot && e.userId && e.inputTranscript, handler: handleLex },
-  { check: e => e.arguments && e.identity && e.info, handler: handleAppSync },
-  { check: e => e.clientId && e.topic && e.payload, handler: handleIoTRule },
-  { check: e => e.records && Array.isArray(e.records) && e.records[0]?.recordId, handler: handleFirehose },
-  { check: e => e.invokingEvent && e.ruleParameters && e.resultToken, handler: handleConfigRule },
-  { check: e => e.taskToken || e.source === 'aws.states', handler: handleStepFunctions },
-  { check: e => e.version === '2.0' && e.requestContext?.routeKey && e.requestContext?.connectionId, handler: handleWebSocket },
-  { check: e => e.type === 'TOKEN' && e.methodArn, handler: handleAuthorizerV1 },
-  { check: e => e.version === '2.0' && e.type === 'REQUEST', handler: handleAuthorizerV2 },
-  { check: e => e.version === '2.0' && e.requestContext?.http?.method, handler: handleHttpV2 },
-  { check: e => e.httpMethod, handler: handleHttpV1 },
-  { check: e => e.requestContext?.elb, handler: handleAlb },
-  { check: e => e.Records && e.Records[0]?.cf, handler: handleEdge },
-  { check: e => e.awslogs?.data, handler: handleCloudWatchLogs },
-  { check: e => e.RequestType && e.ResponseURL, handler: handleCustomResource },
-  { check: e => e.triggerSource && e.userPoolId, handler: handleCognito },
-  { check: e => getRecordsSource(e) === 'aws:sqs', handler: handleSqs },
-  { check: e => getRecordsSource(e) === 'aws:sns', handler: handleSns },
-  { check: e => getRecordsSource(e) === 'aws:s3', handler: handleS3 },
-  { check: e => getRecordsSource(e) === 'aws:dynamodb', handler: handleDynamoDB },
-  { check: e => getRecordsSource(e) === 'aws:kinesis', handler: handleKinesis },
-  { check: e => getRecordsSource(e) === 'aws:ses', handler: handleSes },
-  { check: e => e.source === 'aws.events', handler: handleScheduled },
-  { check: e => e.source && e['detail-type'], handler: handleEventBridge },
-];
+// Load dispatch configuration at startup. The promise resolves to an array of
+// { check, handler } objects used during event dispatch.
+const dispatchTablePromise = loadDispatchTable();
 
 /**
  * Main Lambda entry point used by AWS.
@@ -90,6 +24,7 @@ const dispatchTable = [
 export async function handler(event, context) {
   logDebug('dispatcher', { requestId: context.awsRequestId });
   try {
+    const dispatchTable = await dispatchTablePromise;
     for (const { check, handler: h } of dispatchTable) {
       if (check(event)) {
         return await h(event, context);


### PR DESCRIPTION
## Summary
- load dispatch table from new `dispatch-config.js`
- create `dispatcher.js` helper
- update README with configuration docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687771a0bd648325bfc18d22d93a79af