### PR TITLE
Add CLI invocation helper and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,16 @@ Run the unit tests with:
 npm test
 ```
 
+## CLI Usage
+
+Invoke the handler locally with a JSON event file:
+
+```bash
+npm run invoke -- examples/http-v1.json
+```
+
+Sample payloads for all supported sources live under the `examples/` directory.
+
 ## Contributing
 
 Issues and pull requests are welcome. If adding new handlers or tests,

--- a/bin/invoke.js
+++ b/bin/invoke.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import fs from 'fs/promises';
+import path from 'path';
+import { handler } from '../index.mjs';
+
+async function main() {
+  const file = process.argv[2];
+  if (!file) {
+    console.error('Usage: node bin/invoke.js <event.json>');
+    process.exit(1);
+  }
+
+  const eventPath = path.resolve(process.cwd(), file);
+  const data = await fs.readFile(eventPath, 'utf8');
+  const event = JSON.parse(data);
+  const context = { awsRequestId: 'cli' };
+  const result = await handler(event, context);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/alb.json
+++ b/examples/alb.json
@@ -1,0 +1,4 @@
+{
+  "requestContext": { "elb": {} },
+  "path": "/alb"
+}

--- a/examples/alexa.json
+++ b/examples/alexa.json
@@ -1,0 +1,5 @@
+{
+  "request": { "type": "IntentRequest" },
+  "session": { "sessionId": "abc" },
+  "context": { "System": {} }
+}

--- a/examples/appsync.json
+++ b/examples/appsync.json
@@ -1,0 +1,5 @@
+{
+  "arguments": {},
+  "identity": {},
+  "info": { "fieldName": "test" }
+}

--- a/examples/authorizer-v1.json
+++ b/examples/authorizer-v1.json
@@ -1,0 +1,5 @@
+{
+  "type": "TOKEN",
+  "methodArn": "arn",
+  "authorizationToken": "abc"
+}

--- a/examples/authorizer-v2.json
+++ b/examples/authorizer-v2.json
@@ -1,0 +1,6 @@
+{
+  "version": "2.0",
+  "type": "REQUEST",
+  "routeArn": "arn",
+  "requestContext": { "http": { "method": "GET" } }
+}

--- a/examples/cloudwatch-logs.json
+++ b/examples/cloudwatch-logs.json
@@ -1,0 +1,5 @@
+{
+  "awslogs": {
+    "data": "H4sIAAAAAAAAA6tWyk0tLk5MTw2pLEhVslJycQxxjPd1DQ52dHdV0lHKyU93LUvNKylWsoquVspMUbJSMlTSUSrJzE0tLknMLVCyMtCBmaBkpZSRqVQbWwsAlhsvKFQAAAA="
+  }
+}

--- a/examples/cognito.json
+++ b/examples/cognito.json
@@ -1,0 +1,7 @@
+{
+  "triggerSource": "PreSignUp_SignUp",
+  "userPoolId": "pool",
+  "userName": "u",
+  "request": {},
+  "response": {}
+}

--- a/examples/config-rule.json
+++ b/examples/config-rule.json
@@ -1,0 +1,5 @@
+{
+  "invokingEvent": "{}",
+  "ruleParameters": "{}",
+  "resultToken": "t"
+}

--- a/examples/custom-resource.json
+++ b/examples/custom-resource.json
@@ -1,0 +1,4 @@
+{
+  "RequestType": "Create",
+  "ResponseURL": "https://example.com"
+}

--- a/examples/dynamodb.json
+++ b/examples/dynamodb.json
@@ -1,0 +1,5 @@
+{
+  "Records": [
+    { "eventSource": "aws:dynamodb", "eventID": "1", "dynamodb": {} }
+  ]
+}

--- a/examples/edge.json
+++ b/examples/edge.json
@@ -1,0 +1,10 @@
+{
+  "Records": [
+    {
+      "cf": {
+        "config": { "eventType": "viewer-request" },
+        "request": { "uri": "/index.html", "method": "GET", "headers": {} }
+      }
+    }
+  ]
+}

--- a/examples/eventbridge.json
+++ b/examples/eventbridge.json
@@ -1,0 +1,5 @@
+{
+  "source": "aws.ec2",
+  "detail-type": "EC2 Event",
+  "detail": {}
+}

--- a/examples/firehose.json
+++ b/examples/firehose.json
@@ -1,0 +1,5 @@
+{
+  "records": [
+    { "recordId": "1", "data": "SGVsbG8=" }
+  ]
+}

--- a/examples/http-v1.json
+++ b/examples/http-v1.json
@@ -1,0 +1,4 @@
+{
+  "httpMethod": "GET",
+  "path": "/hello"
+}

--- a/examples/http-v2.json
+++ b/examples/http-v2.json
@@ -1,0 +1,6 @@
+{
+  "version": "2.0",
+  "requestContext": { "http": { "method": "GET" } },
+  "rawPath": "/p",
+  "rawQueryString": ""
+}

--- a/examples/iot.json
+++ b/examples/iot.json
@@ -1,0 +1,5 @@
+{
+  "clientId": "c1",
+  "topic": "topic",
+  "payload": "msg"
+}

--- a/examples/kinesis.json
+++ b/examples/kinesis.json
@@ -1,0 +1,5 @@
+{
+  "Records": [
+    { "eventSource": "aws:kinesis", "kinesis": { "data": "aGk=" } }
+  ]
+}

--- a/examples/lex.json
+++ b/examples/lex.json
@@ -1,0 +1,5 @@
+{
+  "bot": { "name": "TestBot" },
+  "userId": "u1",
+  "inputTranscript": "hi"
+}

--- a/examples/s3.json
+++ b/examples/s3.json
@@ -1,0 +1,8 @@
+{
+  "Records": [
+    {
+      "eventSource": "aws:s3",
+      "s3": { "bucket": { "name": "my-bucket" }, "object": { "key": "file.txt" } }
+    }
+  ]
+}

--- a/examples/scheduled.json
+++ b/examples/scheduled.json
@@ -1,0 +1,6 @@
+{
+  "source": "aws.events",
+  "id": "1",
+  "detail-type": "Scheduled Event",
+  "time": "2022-01-01T00:00:00Z"
+}

--- a/examples/ses.json
+++ b/examples/ses.json
@@ -1,0 +1,11 @@
+{
+  "Records": [
+    {
+      "eventSource": "aws:ses",
+      "ses": {
+        "mail": { "messageId": "1", "source": "a@b.com", "commonHeaders": { "subject": "Hi" } },
+        "receipt": {}
+      }
+    }
+  ]
+}

--- a/examples/sns.json
+++ b/examples/sns.json
@@ -1,0 +1,5 @@
+{
+  "Records": [
+    { "eventSource": "aws:sns", "Sns": { "MessageId": "1", "Message": "msg" } }
+  ]
+}

--- a/examples/sqs.json
+++ b/examples/sqs.json
@@ -1,0 +1,5 @@
+{
+  "Records": [
+    { "eventSource": "aws:sqs", "messageId": "1", "receiptHandle": "rh", "body": "msg" }
+  ]
+}

--- a/examples/step-functions.json
+++ b/examples/step-functions.json
@@ -1,0 +1,4 @@
+{
+  "taskToken": "tok",
+  "input": { "foo": "bar" }
+}

--- a/examples/websocket.json
+++ b/examples/websocket.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0",
+  "requestContext": {
+    "routeKey": "$default",
+    "connectionId": "1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "lint": "eslint .",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "package": "npm pack"
+    "package": "npm pack",
+    "invoke": "node bin/invoke.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `bin/invoke.js` script for local testing
- provide sample event payloads under `examples/`
- expose `npm run invoke` script
- document CLI usage in README

## Testing
- `npm run lint`
- `npm test`
- `node bin/invoke.js examples/http-v1.json`

------
https://chatgpt.com/codex/tasks/task_b_687776f427408325aa59c20594672804