### PR TITLE
Validate handler paths during dispatch table load

### DIFF
--- a/dispatcher.js
+++ b/dispatcher.js
@@ -54,7 +54,11 @@ const handlerMap = {
 
 export async function loadDispatchTable() {
   const { default: config } = await import('./dispatch-config.js');
-  return config.map(({ check, handler }) => ({ check, handler: handlerMap[handler] }));
+  return config.map(({ check, handler }) => {
+    const fn = handlerMap[handler];
+    if (!fn) throw new Error(`Unknown handler path: ${handler}`);
+    return { check, handler: fn };
+  });
 }
 
 export const dispatchTablePromise = loadDispatchTable();

--- a/tests/dispatcher.test.js
+++ b/tests/dispatcher.test.js
@@ -1,0 +1,10 @@
+import config from '../dispatch-config.js';
+import { loadDispatchTable } from '../dispatcher.js';
+
+describe('loadDispatchTable', () => {
+  test('throws for unknown handler path', async () => {
+    config.push({ check: () => true, handler: './handlers/missing.js' });
+    await expect(loadDispatchTable()).rejects.toThrow('Unknown handler path: ./handlers/missing.js');
+    config.pop();
+  });
+});


### PR DESCRIPTION
## Summary
- validate handler path lookups when building dispatch table
- test loading dispatch table with invalid handler path

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b6252673d48325b53bbdaa93f7e196