### PR TITLE
Validate CloudFront event requests in edge handler

### DIFF
--- a/handlers/handleEdge.js
+++ b/handlers/handleEdge.js
@@ -17,6 +17,7 @@ export default async function handleEdge(event, context) {
   const invocation = collectInvocation(event, context, 'edge');
   logDebug('invocation', invocation);
   logDebug('handleEdge', { eventType: event.Records?.[0]?.cf?.config?.eventType, requestId: context.awsRequestId });
-  const request = event.Records[0].cf.request;
+  const request = event.Records?.[0]?.cf?.request;
+  if (!request) return { error: 'Invalid CloudFront event' };
   return request;
 }

--- a/tests/handlers.test.js
+++ b/tests/handlers.test.js
@@ -120,6 +120,20 @@ describe('handler dispatch', () => {
     expect(result).toEqual(request);
   });
 
+  test('handles malformed Edge event', async () => {
+    const event = { Records: [ { cf: { config: { eventType: 'viewer-request' } } } ] };
+    const context = { awsRequestId: '1' };
+    const result = await handler(event, context);
+    expect(result).toEqual({ error: 'Invalid CloudFront event' });
+  });
+
+  test('falls back to default handler when cf missing', async () => {
+    const event = { Records: [ {} ] };
+    const context = { awsRequestId: '1' };
+    const result = await handler(event, context);
+    expect(result).toEqual({ fallback: true });
+  });
+
   test('handles CloudWatch Logs event', async () => {
     const payload = { messageType: 'DATA_MESSAGE', logEvents: [ { id: '1', timestamp: 0, message: 'hi' } ] };
     const data = zlib.gzipSync(JSON.stringify(payload)).toString('base64');


### PR DESCRIPTION
## Summary
- guard handleEdge against malformed CloudFront events using optional chaining
- add tests for invalid Edge events and default fallback

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b62753ca40832587f607c69f31bafa