### PR TITLE
Gracefully handle malformed CloudWatch Logs data

### DIFF
--- a/handlers/handleCloudWatchLogs.js
+++ b/handlers/handleCloudWatchLogs.js
@@ -17,10 +17,15 @@ export default async function handleCloudWatchLogs(event, context) {
   const invocation = collectInvocation(event, context, 'cloudWatchLogs');
   logDebug('invocation', invocation);
   logDebug('handleCloudWatchLogs', { requestId: context.awsRequestId });
-  // Decode the base64 gzipped log payload
-  const compressed = Buffer.from(event.awslogs.data, 'base64');
-  const json = zlib.gunzipSync(compressed).toString('utf8');
-  const payload = JSON.parse(json);
-  payload.logEvents?.forEach(e => console.log('CloudWatch:', e.message));
-  return payload.logEvents || [];
+  try {
+    // Decode the base64 gzipped log payload
+    const compressed = Buffer.from(event.awslogs.data, 'base64');
+    const json = zlib.gunzipSync(compressed).toString('utf8');
+    const payload = JSON.parse(json);
+    payload.logEvents?.forEach(e => console.log('CloudWatch:', e.message));
+    return payload.logEvents || [];
+  } catch (err) {
+    console.error('Failed to process CloudWatch Logs', err);
+    return [];
+  }
 }

--- a/tests/handlers.test.js
+++ b/tests/handlers.test.js
@@ -143,6 +143,21 @@ describe('handler dispatch', () => {
     expect(result).toEqual(payload.logEvents);
   });
 
+  test('returns empty array on malformed CloudWatch Logs data', async () => {
+    const data = Buffer.from('not gzipped').toString('base64');
+    const event = { awslogs: { data } };
+    const context = { awsRequestId: '1' };
+    const result = await handler(event, context);
+    expect(result).toEqual([]);
+  });
+
+  test('falls back to default handler on empty CloudWatch Logs data', async () => {
+    const event = { awslogs: { data: '' } };
+    const context = { awsRequestId: '1' };
+    const result = await handler(event, context);
+    expect(result).toEqual({ fallback: true });
+  });
+
   test('handles Custom Resource event', async () => {
     const event = { RequestType: 'Create', ResponseURL: 'https://example.com' };
     const context = { awsRequestId: '1' };


### PR DESCRIPTION
## Summary
- wrap CloudWatch Logs payload decoding in try/catch and log failures
- return empty list when parsing fails
- test malformed and empty CloudWatch Logs data

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b629a9fcbc8325a0d024ae18d8bd13