### PR TITLE
feat: handle circular payloads in debug logging

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -2,14 +2,27 @@
  * Conditionally log debugging information.
  *
  * Messages are only output when the `DEBUG` environment variable is set.
- * Payloads that are not strings are serialized to JSON.
+ * Payloads that are not strings are serialized to JSON. If serialization
+ * fails (e.g. due to circular references) we fall back to `util.inspect` so
+ * that debugging information is still output without throwing errors.
  *
  * @param {string} label - Message label used to group debug output.
  * @param {any} payload - Additional context to log.
  */
+import { inspect } from 'node:util';
+
 export function logDebug(label, payload) {
   if (process.env.DEBUG) {
-    const msg = typeof payload === 'string' ? payload : JSON.stringify(payload);
+    let msg;
+    if (typeof payload === 'string') {
+      msg = payload;
+    } else {
+      try {
+        msg = JSON.stringify(payload);
+      } catch {
+        msg = inspect(payload);
+      }
+    }
     console.debug(label, msg);
   }
 }

--- a/tests/logger.test.js
+++ b/tests/logger.test.js
@@ -1,0 +1,28 @@
+import { logDebug } from '../logger.js';
+
+describe('logDebug', () => {
+  const originalDebug = console.debug;
+  let messages;
+
+  beforeEach(() => {
+    messages = [];
+    console.debug = (...args) => {
+      messages.push(args.join(' '));
+    };
+    process.env.DEBUG = '1';
+  });
+
+  afterEach(() => {
+    console.debug = originalDebug;
+    delete process.env.DEBUG;
+  });
+
+  test('logs circular structures without throwing', () => {
+    const obj = {};
+    obj.self = obj;
+
+    expect(() => logDebug('label', obj)).not.toThrow();
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain('label');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `logDebug` safely stringifies payloads and falls back to `util.inspect`
- add tests for circular structures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b62cb79bc0832598dcdd8dd1f624de