### PR TITLE
Handle errors from context functions during invocation collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,3 +198,5 @@ aws lambda invoke \
 ## Debugging
 
 Set `DEBUG=1` (or any non-empty value) to enable additional log output. This can help troubleshoot event dispatching and handler execution.
+
+When invocation data is collected, functions on the `context` object are invoked. If a context function throws an error, its message is captured and included in the logged context instead of halting execution.

--- a/tests/collectInvocation.test.js
+++ b/tests/collectInvocation.test.js
@@ -21,4 +21,20 @@ describe('collectInvocation', () => {
       handlerType: 'test'
     });
   });
+
+  test('handles context functions that throw', () => {
+    const event = {};
+    const context = {
+      ok: () => 'good',
+      fail() { throw new Error('boom'); }
+    };
+
+    const result = collectInvocation(event, context, 'test');
+
+    expect(result).toEqual({
+      event,
+      context: { ok: 'good', fail: 'boom' },
+      handlerType: 'test'
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- capture errors from context functions when building invocation data
- document context error handling in README
- add tests verifying thrown context functions are recorded gracefully

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b631d373988325b8a1c666827152b5