### PR TITLE
refactor: import dispatch table once

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -6,12 +6,11 @@
  * under the `handlers/` directory.
  */
 import { logDebug } from './logger.js';
-import { loadDispatchTable } from './dispatcher.js';
+import { dispatchTablePromise } from './dispatcher.js';
 import handleDefault from './handlers/handleDefault.js';
 
-// Load dispatch configuration at startup. The promise resolves to an array of
-// { check, handler } objects used during event dispatch.
-const dispatchTablePromise = loadDispatchTable();
+// Dispatch configuration is loaded on module import. The promise resolves to an
+// array of { check, handler } objects used during event dispatch.
 
 /**
  * Main Lambda entry point used by AWS.

--- a/tests/handlers.test.js
+++ b/tests/handlers.test.js
@@ -254,9 +254,9 @@ describe('handler dispatch', () => {
         throw new Error('boom');
       });
       jest.unstable_mockModule('../dispatcher.js', () => ({
-        loadDispatchTable: async () => [
+        dispatchTablePromise: Promise.resolve([
           { check: () => true, handler: failingHandler },
-        ],
+        ]),
       }));
       const { handler } = await import('../index.mjs');
       const event = { httpMethod: 'GET', path: '/err' };
@@ -276,9 +276,9 @@ describe('handler dispatch', () => {
         throw new Error('boom');
       });
       jest.unstable_mockModule('../dispatcher.js', () => ({
-        loadDispatchTable: async () => [
+        dispatchTablePromise: Promise.resolve([
           { check: e => e.requestContext?.routeKey, handler: failingHandler },
-        ],
+        ]),
       }));
       const { handler } = await import('../index.mjs');
       const event = { version: '2.0', requestContext: { routeKey: '$default', connectionId: '1' } };


### PR DESCRIPTION
## Summary
- load dispatch table in dispatcher and import its promise in index.mjs
- update handler tests to mock dispatchTablePromise

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b6478706188325a42a431c68278c35