### PR TITLE
Handle non-object events safely

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -32,8 +32,13 @@ export async function handler(event, context) {
     return await handleDefault(event, context);
   } catch (err) {
     console.error('Error processing event', err);
-    // For HTTP or WebSocket requests, return an error response
-    if (event.httpMethod || (event.version === '2.0' && (event.requestContext?.http?.method || event.requestContext?.routeKey))) {
+    const isObjectEvent = typeof event === 'object' && event;
+    const isHttpOrWs =
+      isObjectEvent &&
+      (event.httpMethod ||
+        (event.version === '2.0' &&
+          (event.requestContext?.http?.method || event.requestContext?.routeKey)));
+    if (!isObjectEvent || isHttpOrWs) {
       return {
         statusCode: 500,
         headers: { 'Content-Type': 'application/json' },

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -28,4 +28,14 @@ describe('handler', () => {
     const result = await handler(event, context);
     expect(result).toEqual({ processed: 1 });
   });
+
+  test('gracefully handles undefined event', async () => {
+    const context = { awsRequestId: '1' };
+    const result = await handler(undefined, context);
+    expect(result).toEqual({
+      statusCode: 500,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Internal Server Error' }),
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Guard catch block against non-object events before property access
- Return generic 500 response when event is undefined
- Add regression test for undefined events

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b64a82afb4832598c83f25fe944ee1