### PR TITLE
Omit event payload from HTTP responses

### DIFF
--- a/handlers/handleAlb.js
+++ b/handlers/handleAlb.js
@@ -19,10 +19,11 @@ export default async function handleAlb(event, context) {
   const invocation = collectInvocation(event, context, 'alb');
   logDebug('invocation', invocation);
   logDebug('handleAlb', { method: event.httpMethod, path: event.path, requestId: context.awsRequestId });
+  logDebug('event', event);
   return {
     statusCode: 200,
     statusDescription: '200 OK',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ message: 'Hello from ALB', event }),
+    body: JSON.stringify({ message: 'Hello from ALB' }),
   };
 }

--- a/handlers/handleHttpV1.js
+++ b/handlers/handleHttpV1.js
@@ -18,9 +18,10 @@ export default async function handleHttpV1(event, context) {
   const invocation = collectInvocation(event, context, 'httpV1');
   logDebug('invocation', invocation);
   logDebug('handleHttpV1', { method: event.httpMethod, path: event.path, requestId: context.awsRequestId });
+  logDebug('event', event);
   return {
     statusCode: 200,
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ message: 'Hello from API Gateway v1', event }),
+    body: JSON.stringify({ message: 'Hello from API Gateway v1' }),
   };
 }

--- a/handlers/handleHttpV2.js
+++ b/handlers/handleHttpV2.js
@@ -19,9 +19,10 @@ export default async function handleHttpV2(event, context) {
   const invocation = collectInvocation(event, context, 'httpV2');
   logDebug('invocation', invocation);
   logDebug('handleHttpV2', { method: event.requestContext?.http?.method, path: event.rawPath, requestId: context.awsRequestId });
+  logDebug('event', event);
   return {
     statusCode: 200,
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ message: 'Hello from API Gateway v2', event }),
+    body: JSON.stringify({ message: 'Hello from API Gateway v2' }),
   };
 }

--- a/tests/handlers.test.js
+++ b/tests/handlers.test.js
@@ -100,7 +100,7 @@ describe('handler dispatch', () => {
     expect(result).toEqual({
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ message: 'Hello from API Gateway v2', event })
+      body: JSON.stringify({ message: 'Hello from API Gateway v2' })
     });
   });
 
@@ -112,7 +112,7 @@ describe('handler dispatch', () => {
       statusCode: 200,
       statusDescription: '200 OK',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ message: 'Hello from ALB', event })
+      body: JSON.stringify({ message: 'Hello from ALB' })
     });
   });
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -11,7 +11,7 @@ describe('handler', () => {
     expect(result).toEqual({
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ message: 'Hello from API Gateway v1', event })
+      body: JSON.stringify({ message: 'Hello from API Gateway v1' })
     });
   });
 


### PR DESCRIPTION
## Summary
- Avoid returning entire event payload in HTTP v1, HTTP v2, and ALB handlers
- Add debug logging of raw events for troubleshooting
- Adjust tests for new response shape

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npx jest --runInBand --silent`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b651c7fd8083258e697ea6c76b3239